### PR TITLE
Make Jekyll Version ~> 3.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.0"
+gem "jekyll", "~> 3.2.1"
 gem "jekyll-sitemap"
 gem "jekyll-gist"
 gem 'jekyll-mentions'


### PR DESCRIPTION
This is so fenced ``` codeblocks will be rendered as pre tags instead
of a series of code tags on gh-pages See: [https://github.com/jekyll/jekyll/issues/4448](https://github.com/jekyll/jekyll/issues/4448)
