### PR TITLE
Fix FontAwesome path

### DIFF
--- a/_sass/vendor/font-awesome/_variables.scss
+++ b/_sass/vendor/font-awesome/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-$fa-font-path:        "../fonts/FontAwesome/" !default;
+$fa-font-path:        "../fonts/FontAwesome" !default;
 $fa-font-size-base:   14px !default;
 $fa-line-height-base: 1 !default;
 //$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.7.0/fonts" !default; // for referencing Bootstrap CDN font files directly


### PR DESCRIPTION
$fa-font-path ends has a trailing slash, which that browsers will do requests towards /assets/fonts/FontAwesome//fontawesome-webfont.{eot,woff,ttf} as per _sass/vendor/font-awesome/_path.scss .

For most of modern web servers it's fine, as they will flatten more than 1 forward slash to 1. That is: a//b -> a/b ... However this is not the case when hosting the page in a Amazon AWS S3 bucket, as it interprets it as a literal path that doesn't exist.

Removing the trailing slash from $fa-font-path solves the issue.

See: https://forums.aws.amazon.com/thread.jspa?threadID=13898