### PR TITLE
Show home instead of back button in page layout

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -18,7 +18,7 @@ layout: compress
                 <div class="post-title {% if page.feature %} feature {% endif %}">
                     <h1>{{ page.title }}</h1>
                     <a class="btn zoombtn" href="{{site.url}}">
-                        <i class="fa fa-chevron-left"></i>
+                        <i class="fa fa-home"></i>
                     </a>
                 </div>
                 {{ content }}


### PR DESCRIPTION
The "page" layout is currently used in the about page, tag archive and 404 page. On these pages, underneath the title, there is a left-arrow button suggesting to the user that a browser-back navigation will be performed, but actually a navigation to the home page `/` is performed.
To improve UX, I propose to show the home button on these pages instead of the left-arrow button.