### PR TITLE
Remove url from example _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,6 @@ logo:               'assets/img/logo.png'
 background:         'assets/img/placeholder-big.jpg'
 tiled_bg:           false   # Set this true if you want to tile your background image, otherwise it will be covered
 locale:             en_US
-url:                https://taylantatli.github.io/Moon
 
 # Jekyll
 permalink:          /:title/


### PR DESCRIPTION
Currently, the value site.url is set in _config.yml which suggests to users who fork the repo that they should replace this value with their own GitHub Pages URL.
However, if you have site.url set and test the page on localhost, all internal links (like the buttons to `/about` on the landing page) will lead to the "production page" hosted on GitHub Pages.
Therefore, I propose to remove this line so internal links on localhost will still lead to localhost. In production, they will still lead to production. Alternatively, one could remove the occurrences of `{{ site.url }}` in links.